### PR TITLE
Travis CI build now passing, removeWhitespaceCharacters() now removes embeded multiple spaces 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 URL: https://github.com/MangoTheCat/sasMap
 BugReports: https://github.com/mangothecat/sasMap/issues
 License: MIT + file LICENSE
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/remove.R
+++ b/R/remove.R
@@ -73,6 +73,6 @@ removeAllComments <- function(sasCode){
 removeWhitespaceCharacters <- function(sasCode){
   sasCode <- stringr::str_replace_all(sasCode, "^ *?", "")
   sasCode <- stringr::str_replace_all(sasCode, "[\r\n\\\r\\\n\t]", " ")
-  stringr::str_trim(sasCode)
+  stringr::str_squish(sasCode)
   
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sasMap
 
-[![Travis-CI Build Status](https://travis-ci.com/PolloPequeno/sasMap.svg?branch=Pollo)](https://travis-ci.com/github/PolloPequeno/sasMapp) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/sasMap)](http://cran.r-project.org/package=sasMap) [![](http://cranlogs.r-pkg.org/badges/sasMap)](http://cran.rstudio.com/web/packages/sasMap/index.html) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/sasMap/master.svg)](https://codecov.io/gh/MangoTheCat/sasMap)
+[![Travis-CI Build Status](https://travis-ci.com/PolloPequeno/sasMap.svg?branch=Pollo)](https://travis-ci.com/github/PolloPequeno/sasMap) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/sasMap)](http://cran.r-project.org/package=sasMap) [![](http://cranlogs.r-pkg.org/badges/sasMap)](http://cran.rstudio.com/web/packages/sasMap/index.html) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/sasMap/master.svg)](https://codecov.io/gh/MangoTheCat/sasMap)
 
 
 > Static code analysis for SAS scripts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sasMap
 
-[![Travis-CI Build Status](https://travis-ci.org/MangoTheCat/sasMap.svg?branch=master)](https://travis-ci.org/MangoTheCat/sasMap) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/sasMap)](http://cran.r-project.org/package=sasMap) [![](http://cranlogs.r-pkg.org/badges/sasMap)](http://cran.rstudio.com/web/packages/sasMap/index.html) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/sasMap/master.svg)](https://codecov.io/gh/MangoTheCat/sasMap)
+[![Travis-CI Build Status](https://travis-ci.com/PolloPequeno/sasMap.svg?branch=Pollo)](https://travis-ci.com/github/PolloPequeno/sasMapp) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/sasMap)](http://cran.r-project.org/package=sasMap) [![](http://cranlogs.r-pkg.org/badges/sasMap)](http://cran.rstudio.com/web/packages/sasMap/index.html) [![Coverage Status](https://img.shields.io/codecov/c/github/MangoTheCat/sasMap/master.svg)](https://codecov.io/gh/MangoTheCat/sasMap)
 
 
 > Static code analysis for SAS scripts

--- a/man/extractMacroCalls.Rd
+++ b/man/extractMacroCalls.Rd
@@ -4,8 +4,11 @@
 \alias{extractMacroCalls}
 \title{Extract macro calls from a string of SAS code}
 \usage{
-extractMacroCalls(sasCode, ignoreList = c("macro", "mend", "global", "let",
-  "put", "if", "do", "end", "else"))
+extractMacroCalls(
+  sasCode,
+  ignoreList = c("macro", "mend", "global", "let", "put", "if", "do", "end", "else",
+    "sysrput", "sysfunc", "symput")
+)
 }
 \arguments{
 \item{sasCode}{SAS code}

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -14,7 +14,7 @@ test_that("Extracts macro definitions", {
 
 test_that("Extracts macro calls", {
   
-  expect_equal(extractMacroCalls(sasCode1), "modelcode")
+  expect_equal(extractMacroCalls(sasCode1), c("init","modelcode"))
   expect_equal(extractMacroCalls(sasCode2), "fun1")
   
 })


### PR DESCRIPTION
Hi,

 Great project, hoping I can contribute to it.

**Travis build now passing**: issue was with the test code. extractMacroCalls() is working as expected.

**removeWhitespaceCharacters()**

Was like this:
  
![image](https://user-images.githubusercontent.com/31669874/110338495-0acf3980-7ff5-11eb-9af3-f07aafb15029.png)

Now is:

![image](https://user-images.githubusercontent.com/31669874/110338271-cfcd0600-7ff4-11eb-8a3e-3ecf44631c4b.png)


Best!    


P.S. Updated the readme to point to my Travis-ci build for testing my fork/branch.


